### PR TITLE
AWS SDK should be listed as a normal dependency, not a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/silvermine/dynamodb-capacity-manager#readme",
   "dependencies": {
+    "aws-sdk": "2.5.4",
     "class.extend": "0.9.2",
     "moment": "2.14.1",
     "q": "1.4.1",
@@ -30,7 +31,6 @@
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "aws-sdk": "2.5.4",
     "coveralls": "2.11.12",
     "eslint": "3.3.1",
     "eslint-config-silvermine": "1.0.0",


### PR DESCRIPTION
The AWS SDK is used throughout the main code base and so should be
listed as a dependency, not a devDependency.
