### PR TITLE
undefined LastIncrease or LastDecrease times block capacity adjustment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamodb-capacity-manager",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Library for monitoring throughput on DynamoDB tables and adjusting it for you based on real-time usage. Can be run as a Lambda function.",
   "main": "src/index.js",
   "scripts": {

--- a/src/boss/rules/DisallowTooSoonOrFrequentRule.js
+++ b/src/boss/rules/DisallowTooSoonOrFrequentRule.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var moment = require('moment'),
+var _ = require('underscore'),
+    moment = require('moment'),
     BaseRule = require('./BaseRule');
 
 module.exports = BaseRule.extend({
@@ -18,11 +19,11 @@ module.exports = BaseRule.extend({
          nextAllowedDecrease = nextAllowedDecAfterInc;
       }
 
-      if (this.isIncreasing(state) && nextAllowedIncrease.isAfter(state.currentTime)) {
+      if (this.isIncreasing(state) && nextAllowedIncrease.isAfter(state.currentTime) && !_.isUndefined(lastIncrease)) {
          state.isAllowedToChange = false;
       }
 
-      if (this.isDecreasing(state)) {
+      if (this.isDecreasing(state) && !_.isUndefined(lastDecrease)) {
          // decrease is being planned - should we stop it?
          if (nextAllowedDecrease.isAfter(state.currentTime) || state.provisioning.NumberOfDecreasesToday >= maxDecreases) {
             state.isAllowedToChange = false;

--- a/src/tests/boss/rules/DisallowTooSoonOrFrequentRule.test.js
+++ b/src/tests/boss/rules/DisallowTooSoonOrFrequentRule.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var expect = require('expect.js'),
+var _ = require('underscore'),
+    expect = require('expect.js'),
     moment = require('moment'),
     Rule = require('../../../boss/rules/DisallowTooSoonOrFrequentRule');
 
@@ -8,7 +9,8 @@ describe('DisallowTooSoonOrFrequent', function() {
 
    describe('apply', function() {
 
-      function runTest(nextCapacity, time, numberDec, expectation, configOpts) {
+      // eslint-disable-next-line max-params
+      function runTest(nextCapacity, time, numberDec, expectation, configOpts, provisioningOverride) {
          var state, config, rule;
 
          configOpts = configOpts || {};
@@ -23,6 +25,8 @@ describe('DisallowTooSoonOrFrequent', function() {
             currentTime: moment(time),
             nextCapacity: nextCapacity,
          };
+
+         state.provisioning = _.extend(state.provisioning, provisioningOverride || {});
 
          config = {
             MaximumDecreasesToUsePerDay: configOpts.maxDecreases || 4,
@@ -112,6 +116,14 @@ describe('DisallowTooSoonOrFrequent', function() {
          runTest(50, '2016-08-18T20:15:01.000Z', 0, undefined, { decAfterInc: 1, maxDecreases: 3 });
          runTest(50, '2016-08-18T20:15:01.000Z', 1, undefined, { decAfterInc: 1, maxDecreases: 3 });
          runTest(50, '2016-08-18T20:15:01.000Z', 2, undefined, { decAfterInc: 1, maxDecreases: 3 });
+      });
+
+      it('allows increase when LastIncreaseDateTime is undefined', function() {
+         runTest(200, '2016-08-18T20:05:01.000Z', 0, undefined, {}, { LastIncreaseDateTime: undefined });
+      });
+
+      it('allows decrease when LastDecreaseDateTime is undefined', function() {
+         runTest(50, '2016-08-18T20:05:01.000Z', 0, undefined, {}, { LastDecreaseDateTime: undefined });
       });
 
    });


### PR DESCRIPTION
In the DisallowTooSoonOrFrequentRule rule, LastIncreaseDateTime and LastDecreaseDateTime
may sometimes be undefined. Previously, those undefined values caused the rule to fall back
to using the current timestamp as the LastIncrease or LastDecrease date, which effectively meant
this rule would always prevent a decrease or increase when one was needed.

This fix handles the undefined value, allowing an increase or decrease if one is needed.