### PR TITLE
Upgrade js-yaml to 3.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt": "1.0.1",
     "grunt-eslint": "19.0.0",
     "istanbul": "0.4.4",
-    "js-yaml": "3.6.1",
+    "js-yaml": "3.8.4",
     "mocha": "3.0.2",
     "mocha-lcov-reporter": "1.2.0",
     "rewire": "2.5.2",


### PR DESCRIPTION
With the fix for nodeca/js-yaml#342 included in v3.8.4, updating the dependency in this repo to keep things consistent.