### PR TITLE
Prevent sudden drop in capacity when forecast is NaN

### DIFF
--- a/src/boss/RegressionForecaster.js
+++ b/src/boss/RegressionForecaster.js
@@ -26,26 +26,26 @@ module.exports = Class.extend({
 
    _createRegressableTimeSeries: function(data) {
       return _.map(data, function(point) {
-         return [ moment(point.Timestamp).utc().toDate(), point.Value ];
+         return [ moment(point.Timestamp).utc().unix(), point.Value ];
       });
    },
 
    _addEmptySlotsToTimeSeries: function(series, additionalMinutes) {
       var lastPoint = _.last(series),
-          lastTime;
+          lastSeconds;
 
       if (!lastPoint) {
          return;
       }
 
-      lastTime = lastPoint[0];
+      lastSeconds = lastPoint[0];
 
       _.each(_.range(1, additionalMinutes + 1), function() {
-         var time = moment(lastTime).utc().add(1, 'minutes');
+         var seconds = lastSeconds + 60; // Add 1 minute
 
-         series.push([ time.toDate(), null ]);
+         series.push([ seconds, null ]);
 
-         lastTime = time;
+         lastSeconds = seconds;
       });
    },
 

--- a/src/boss/rules/ForecastingRule.js
+++ b/src/boss/rules/ForecastingRule.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var Forecaster = require('../RegressionForecaster'),
+var _ = require('underscore'),
+    Forecaster = require('../RegressionForecaster'),
     BaseRule = require('./BaseRule');
 
 module.exports = BaseRule.extend({
@@ -16,7 +17,17 @@ module.exports = BaseRule.extend({
 
 
    apply: function(state) {
-      var forecast = this._forecaster.forecast(state.usage, this._config.MinutesToForecast) || 1;
+      var forecast = this._forecaster.forecast(state.usage, this._config.MinutesToForecast);
+
+      if (!_.isFinite(forecast)) {
+         console.log(
+            'ERROR: Not changing usage as forecaster did not create a valid forecast (predicted: %s) for the usage %s',
+            forecast,
+            JSON.stringify(state.usage)
+         );
+         state.isAllowedToChange = false;
+         return;
+      }
 
       state.forecastUsage = Math.max(forecast, 1);
    },

--- a/src/tests/boss/rules/ForecastingRule.test.js
+++ b/src/tests/boss/rules/ForecastingRule.test.js
@@ -20,9 +20,9 @@ describe('ForecastingRule', function() {
 
    describe('apply', function() {
 
-      function runTest(forecastValue, expectedForecast) {
+      function runTest(forecastValue, expectedForecast, expectedIsAllowedToChange) {
          var rule = new Rule({ MinutesToForecast: 10 }),
-             state = { usage: 'usage-array' },
+             state = { usage: 'usage-array', isAllowedToChange: true },
              forecaster = { forecast: function() {} },
              mock = sinon.mock(forecaster);
 
@@ -33,6 +33,7 @@ describe('ForecastingRule', function() {
          rule.apply(state);
 
          expect(state.forecastUsage).to.eql(expectedForecast);
+         expect(state.isAllowedToChange).to.eql(expectedIsAllowedToChange === undefined ? true : expectedIsAllowedToChange);
          mock.verify();
       }
 
@@ -40,14 +41,19 @@ describe('ForecastingRule', function() {
          runTest(20, 20);
       });
 
-      it('does not allow zero, negative, or NaN values to be forecast', function() {
+      it('does not allow zero or negative values to be forecast', function() {
          runTest(0, 1);
          runTest(-1, 1);
-         runTest(NaN, 1);
-         runTest(null, 1);
          runTest(-1000, 1);
          runTest(-2.6, 1);
          runTest(0.00001, 1);
+      });
+
+      it('does not allow NaN or Infinity forecasts to adjust the forecast', function() {
+         runTest(NaN, undefined, false);
+         runTest(Infinity, undefined, false);
+         runTest(-Infinity, undefined, false);
+         runTest(null, undefined, false);
       });
 
    });


### PR DESCRIPTION
It has been discovered that some datasets will cause the regression function used by the forecaster to return NaN. This causes bad things to happen. Consider the following scenario: A table is cruising along at 10 RCU, with an average of 8 RCU getting consumed. The capacity manager gets a usage dataset that returns NaN. The forecast rule ends up returning a forecast of 1 RCU [due to its internal default](https://github.com/silvermine/dynamodb-capacity-manager/blob/e364d5cdb3410e03edb6325f2d9de614b829c3d4/src/boss/rules/ForecastingRule.js#L19). Unless `AbsoluteMinimumProvisioned` is set, the capacity manager will drop the provisioning down to 1 RCU and you get to watch the throttled read requests stack up. 😬 

In the sample dataset added to the unit tests, the returned NaN appears to be caused by a lack of precision in the regression calculations (Ah, the joys of really large numbers that have a small fractional part). More explanation can be found in the commit message.

This PR makes two adjustments:

1. Switch from using milliseconds to seconds for the x-axis of the regression. This reduces the size of the numbers that are used in the calculation and still produces similar results as using milliseconds (I did some investigation into using a seconds-based offset, e.g. 0, 60, 120, etc. However simulations indicated this was less efficient than how this is currently using a timestamp, being either seconds or milliseconds).
2. In the event there are still datasets that cause NaN or Infinity to be returned, the forecaster will now log an error and abort the capacity adjustment. Thus leaving the provisioned capacity at its previous level.