### PR TITLE
Add CloudWatch usage data export task

### DIFF
--- a/src/StatisticsRetriever.js
+++ b/src/StatisticsRetriever.js
@@ -11,13 +11,20 @@ module.exports = Class.extend({
 
    getStatistic: function(metricName, resource, minutesBack, fillZeroes, minutesToIgnore) {
       var endTime = moment().utc(),
-          startTime, params;
+          startTime;
 
       // end at the first millisecond of the current minute (do not retrieve partial minute stats)
       endTime.seconds(0).milliseconds(0).subtract(minutesToIgnore, 'minutes');
 
       // start at the specified time
       startTime = endTime.clone().subtract(minutesBack, 'minutes');
+
+      return this.getStatisticForTimeslice(metricName, resource, startTime, endTime, fillZeroes);
+   },
+
+
+   getStatisticForTimeslice: function(metricName, resource, startTime, endTime, fillZeroes) {
+      var params;
 
       params = {
          Namespace: 'AWS/DynamoDB',

--- a/tasks/export-cloudwatch-data-sample.js
+++ b/tasks/export-cloudwatch-data-sample.js
@@ -1,0 +1,93 @@
+'use strict';
+
+var _ = require('underscore'),
+    Q = require('q'),
+    fs = require('fs'),
+    moment = require('moment'),
+    StatisticsRetriever = require('../src/StatisticsRetriever'),
+    constants = require('../src/constants'),
+    stats = new StatisticsRetriever(),
+    MAX_MINUTES_PER_TIMESLICE = 1440;
+
+module.exports = function(grunt) {
+
+   function exportThroughputData(resource, outputFilePath, minutesToRetrieve, minutesToIgnore) {
+      var consumedStatName = 'Consumed' + resource.capacityType,
+          endTime = moment().utc().seconds(0).milliseconds(0).subtract(minutesToIgnore, 'minutes'),
+          latestSliceStartTime = endTime.clone().subtract(Math.min(minutesToRetrieve, MAX_MINUTES_PER_TIMESLICE), 'minutes'),
+          startTime = endTime.clone().subtract(minutesToRetrieve, 'minutes'),
+          timeslices = [ { end: endTime, start: latestSliceStartTime } ],
+          promises;
+
+      timeslices = _.reduce(_.range(0, Math.floor(minutesToRetrieve / MAX_MINUTES_PER_TIMESLICE)), function(memo) {
+         var end = _.last(memo).start.clone(),
+             start = end.clone().subtract(MAX_MINUTES_PER_TIMESLICE, 'minutes');
+
+         if (start.isBefore(startTime)) {
+            start = startTime;
+         }
+
+         if (!end.isSameOrBefore(startTime)) {
+            memo.push({
+               end: end,
+               start: start,
+            });
+         }
+
+         return memo;
+      }, timeslices);
+
+      promises = Q.all(_.map(timeslices, function(timeslice) {
+         return stats.getStatisticForTimeslice(consumedStatName, resource, timeslice.start, timeslice.end, true);
+      }));
+
+      return promises
+         .then(function(data) {
+            var fileData;
+
+            fileData = _.chain(data)
+               .flatten(true)
+               .sortBy(function(point) {
+                  return moment(point.date).unix();
+               })
+               .reduce(function(memo, point) {
+                  return memo + moment(point.date).toISOString() + ' ' + point.value + '\n';
+               }, '')
+               .value();
+
+            return Q.ninvoke(fs, 'writeFile', outputFilePath, fileData, 'utf8');
+         });
+   }
+
+   grunt.registerTask('export-cloudwatch-data-sample', 'Exports throughput data for a given table from CloudWatch', function() {
+      var tableName = grunt.option('table'),
+          outputFile = grunt.option('output-file'),
+          done = this.async(),
+          resource, capacityType, minutesToRetrieve, minutesToIgnore;
+
+      capacityType = (grunt.option('capacity-type') === constants.WRITE ? constants.WRITE : constants.READ);
+      minutesToRetrieve = grunt.option('retrieve-minutes') || (1 * 24 * 60); // Default: 1 day
+      minutesToIgnore = grunt.option('ignore-minutes') || 2; // Default: 2 minutes
+
+      if (_.isEmpty(tableName)) {
+         grunt.fail.fatal('Must supply a --table=<TableName> parameter');
+      }
+      if (_.isEmpty(outputFile)) {
+         grunt.fail.fatal('Must supply a --output-file=<FilePath> parameter');
+      }
+
+      resource = {
+         tableName: tableName,
+         indexName: grunt.option('index-name'),
+         capacityType: capacityType,
+      };
+
+      grunt.log.ok('Exporting throughput data from CloudWatch for', resource);
+
+      return exportThroughputData(resource, outputFile, minutesToRetrieve, minutesToIgnore)
+         .then(done)
+         .catch(done)
+         .done();
+   });
+
+};

--- a/tasks/run-sample-analysis.js
+++ b/tasks/run-sample-analysis.js
@@ -6,6 +6,7 @@ var _ = require('underscore'),
     moment = require('moment'),
     yaml = require('js-yaml'),
     Boss = require('../src/boss/DecisionMaker'),
+    constants = require('../src/constants'),
     HOURS_OF_DATA_FOR_BOSS = 1;
 
 module.exports = function(grunt) {
@@ -43,8 +44,8 @@ module.exports = function(grunt) {
       }
 
       return Q.all([ Q.ninvoke(fs, 'readFile', dataFile), getConfig ])
-         .spread(function(data, config) {
-            boss = new Boss(config);
+         .spread(function(data, userConfig) {
+            boss = new Boss(_.extend({}, constants.DEFAULT_RESOURCE_CONFIG, userConfig));
             return data;
          })
          .then(function(data) {
@@ -54,7 +55,7 @@ module.exports = function(grunt) {
 
                   return {
                      Timestamp: columns[0],
-                     Value: (columns[1] / 60),
+                     Value: columns[1],
                   };
                })
                .sortBy('Timestamp')

--- a/tasks/static-assets/chart.html
+++ b/tasks/static-assets/chart.html
@@ -3,6 +3,24 @@
       <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
       <script type="text/javascript">
          function setData(data) {
+            var totalConsumed, totalProvisioned;
+
+            totalConsumed = data.slice(1).reduce(function(memo, row) {
+               return memo + parseFloat(row[1]);
+            }, 0);
+            totalProvisioned = data.slice(1).reduce(function(memo, row) {
+               return memo + parseFloat(row[2]);
+            }, 0);
+
+            document.addEventListener('DOMContentLoaded', function() {
+               function round(num) {
+                  return Math.round(num * 100) / 100;
+               }
+               document.getElementById('totalConsumed').innerHTML = round(totalConsumed);
+               document.getElementById('totalProvisioned').innerHTML = round(totalProvisioned);
+               document.getElementById('usageEfficiency').innerHTML = round(totalConsumed/totalProvisioned * 100) + '%';
+            }, false);
+
             google.charts.load('current', { packages: [ 'corechart', 'controls' ] });
             google.charts.setOnLoadCallback(drawChart);
 
@@ -68,12 +86,31 @@
          }
       </script>
       <script type="text/javascript" src="./data.js"></script>
+      <style>
+         body {
+            font-family: sans-serif;
+         }
+         #summary {
+            width: 300px;
+            margin: 2em auto 0 auto;
+         }
+         #summary span {
+            font-weight: bold;
+         }
+      </style>
    </head>
 
    <body>
       <div id="dashboard">
          <div id="chart"></div>
          <div id="control"></div>
+      </div>
+      <div id="summary">
+         <ul>
+            <li>Total Consumed: <span id='totalConsumed'></span></li>
+            <li>Total Provisioned: <span id='totalProvisioned'></span></li>
+            <li>Efficiency: <span id='usageEfficiency'></span></li>
+         </ul>
       </div>
    </body>
 </html>


### PR DESCRIPTION
This PR adds a `grunt` task called `export-cloudwatch-data-sample` which exports usage data from CloudWatch for the given table. This can then be used for simulating the behavior of the capacity manager. The following is an example of these task's basic usage.

```
export AWS_REGION='us-east-1'
grunt export-cloudwatch-data-sample --table=MyTable --output-file="MyTable-usage.log"
grunt run-sample-analysis --data-file="MyTable-usage.log" --output-file="MyTable-analysis.csv"
grunt make-chart-from-analysis --input-file="MyTable-analysis.csv" --output-folder="MyTable"
```

This PR also adds a basic "stats" section to the forecast chart to assist in comparing simulations for different configurations.