### PR TITLE
Correctly call regression function for regression-js v2.0.1

### DIFF
--- a/src/boss/RegressionForecaster.js
+++ b/src/boss/RegressionForecaster.js
@@ -50,6 +50,6 @@ module.exports = Class.extend({
    },
 
    _regress: function(series) {
-      return regression(this._regressionType, series).points;
+      return regression[this._regressionType](series, { precision: 50 }).points;
    },
 });

--- a/src/tests/boss/RegressionForecaster.test.js
+++ b/src/tests/boss/RegressionForecaster.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var expect = require('expect.js'),
+    Forecaster = require('../../boss/RegressionForecaster');
+
+describe('RegressionForecastingRule', function() {
+
+   describe('forecast', function() {
+
+      it('makes a numerical forecast', function() {
+         var forecaster = new Forecaster(),
+             usage, forecast;
+
+         usage = [
+            { 'Timestamp': '2018-01-01T01:00:00-00:00', 'Value': 5 },
+            { 'Timestamp': '2018-01-01T01:01:00-00:00', 'Value': 5 },
+            { 'Timestamp': '2018-01-01T01:02:00-00:00', 'Value': 5 },
+            { 'Timestamp': '2018-01-01T01:03:00-00:00', 'Value': 8 },
+            { 'Timestamp': '2018-01-01T01:04:00-00:00', 'Value': 6 },
+            { 'Timestamp': '2018-01-01T01:05:00-00:00', 'Value': 7 },
+            { 'Timestamp': '2018-01-01T01:06:00-00:00', 'Value': 7 },
+            { 'Timestamp': '2018-01-01T01:07:00-00:00', 'Value': 8 },
+            { 'Timestamp': '2018-01-01T01:08:00-00:00', 'Value': 9 },
+            { 'Timestamp': '2018-01-01T01:09:00-00:00', 'Value': 5 },
+            { 'Timestamp': '2018-01-01T01:10:00-00:00', 'Value': 6 },
+            { 'Timestamp': '2018-01-01T01:11:00-00:00', 'Value': 5 },
+            { 'Timestamp': '2018-01-01T01:12:00-00:00', 'Value': 5 },
+            { 'Timestamp': '2018-01-01T01:13:00-00:00', 'Value': 8 },
+            { 'Timestamp': '2018-01-01T01:14:00-00:00', 'Value': 6 },
+            { 'Timestamp': '2018-01-01T01:15:00-00:00', 'Value': 7 },
+            { 'Timestamp': '2018-01-01T01:16:00-00:00', 'Value': 7 },
+            { 'Timestamp': '2018-01-01T01:17:00-00:00', 'Value': 8 },
+            { 'Timestamp': '2018-01-01T01:18:00-00:00', 'Value': 9 },
+            { 'Timestamp': '2018-01-01T01:19:00-00:00', 'Value': 5 },
+         ];
+
+         forecast = forecaster.forecast(usage, 0);
+         expect(forecast).to.be.a('number');
+         expect(forecast).to.be.within(5, 9);
+      });
+
+   });
+
+});


### PR DESCRIPTION
In 4a911526c84373286b4e8325fd54effb9f0affc1 we updated to regresion-js v2.0.1 from v1.2.1. However the regression function API changed between [v1.2.1][1] and [v2.0.1][2]. Additionally a `precision` option was added. Which if left at the default, will produce wildly different output.

[1]: https://github.com/Tom-Alexander/regression-js/tree/1.2.1#polynomial-regression
[2]: https://github.com/Tom-Alexander/regression-js/tree/2.0.1#regressionpolynomialdata-options