### PR TITLE
Fix the "empty" value used in forecast additional minutes calculations

### DIFF
--- a/src/boss/RegressionForecaster.js
+++ b/src/boss/RegressionForecaster.js
@@ -43,7 +43,7 @@ module.exports = Class.extend({
       _.each(_.range(1, additionalMinutes + 1), function() {
          var time = moment(lastTime).utc().add(1, 'minutes');
 
-         series.push([ time.toDate(), undefined ]);
+         series.push([ time.toDate(), null ]);
 
          lastTime = time;
       });

--- a/src/tests/boss/RegressionForecaster.test.js
+++ b/src/tests/boss/RegressionForecaster.test.js
@@ -39,6 +39,36 @@ describe('RegressionForecastingRule', function() {
          expect(forecast).to.be.within(5, 9);
       });
 
+      it('forecasts N minutes ahead', function() {
+         var forecaster = new Forecaster(),
+             usage, forecast;
+
+         usage = [
+            { 'Timestamp': '1970-01-01T00:00:00.000Z', 'Value': 0 },
+            { 'Timestamp': '1970-01-01T00:01:00.000Z', 'Value': 60 },
+            { 'Timestamp': '1970-01-01T00:02:00.000Z', 'Value': 120 },
+            { 'Timestamp': '1970-01-01T00:03:00.000Z', 'Value': 180 },
+            { 'Timestamp': '1970-01-01T00:04:00.000Z', 'Value': 240 },
+         ];
+
+         forecast = forecaster.forecast(usage, 0);
+         expect(forecast).to.be.within(239, 241);
+
+         forecast = forecaster.forecast(usage, 5);
+         expect(forecast).to.be.within(539, 541);
+      });
+
+      it('handles an empty usage dataset', function() {
+         var forecaster = new Forecaster(),
+             forecast;
+
+         forecast = forecaster.forecast([], 0);
+         expect(forecast).to.be(undefined);
+
+         forecast = forecaster.forecast([], 5);
+         expect(forecast).to.be(undefined);
+      });
+
    });
 
 });


### PR DESCRIPTION
The "empty" value check was changed to [a strict equality in regression-js v2.0.0][1] from the [loose equality check that was used in v1.2.1][2].

[1]: https://github.com/Tom-Alexander/regression-js/blob/2.0.0/src/regression.js#L256
[2]: https://github.com/Tom-Alexander/regression-js/blob/1.2.1/src/regression.js#L179