### PR TITLE
Add config option to delay provisioning adjustments right after table creation

### DIFF
--- a/src/resource-listers/base/DynamoResourceLister.js
+++ b/src/resource-listers/base/DynamoResourceLister.js
@@ -39,8 +39,8 @@ module.exports = Class.extend({
             resources.push(this.convertTableToResource(resp.Table, constants.WRITE));
 
             _.each(resp.Table.GlobalSecondaryIndexes, function(index) {
-               resources.push(this.convertIndexToResource(resp.Table.TableName, index, constants.READ));
-               resources.push(this.convertIndexToResource(resp.Table.TableName, index, constants.WRITE));
+               resources.push(this.convertIndexToResource(resp.Table, index, constants.READ));
+               resources.push(this.convertIndexToResource(resp.Table, index, constants.WRITE));
             }.bind(this));
 
             return resources;
@@ -52,6 +52,7 @@ module.exports = Class.extend({
          resourceType: 'table',
          name: resourceUtils.makeResourceName(table.TableName),
          tableName: table.TableName,
+         tableCreationDateTime: table.CreationDateTime,
          capacityType: capacityType,
          provisioning: {
             lastIncrease: table.ProvisionedThroughput.LastIncreaseDateTime,
@@ -62,11 +63,23 @@ module.exports = Class.extend({
       };
    },
 
-   convertIndexToResource: function(tableName, index, capacityType) {
+   convertIndexToResource: function(tableOrName, index, capacityType) {
+      var table = tableOrName;
+
+      if (_.isString(table)) {
+         console.log(
+            'WARNING: Calling convertIndexToResource with a string table name has been '
+            + 'deprecated. Please provide a TableDescription instead. '
+            + '(https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TableDescription.html)'
+         );
+         table = { TableName: table };
+      }
+
       return {
          resourceType: 'index',
-         name: resourceUtils.makeResourceName(tableName, index.IndexName),
-         tableName: tableName,
+         name: resourceUtils.makeResourceName(table.TableName, index.IndexName),
+         tableName: table.TableName,
+         tableCreationDateTime: table.CreationDateTime,
          indexName: index.IndexName,
          capacityType: capacityType,
          provisioning: {

--- a/src/tests/resource-listers/base/DynamoResourceLister.test.js
+++ b/src/tests/resource-listers/base/DynamoResourceLister.test.js
@@ -140,6 +140,7 @@ describe('DynamoResourceLister', function() {
                      resourceType: 'table',
                      name: 'Tbl1',
                      tableName: 'Tbl1',
+                     tableCreationDateTime: 'Mon Apr 18 2017 16:46:37 GMT-0400 (EDT)',
                      capacityType: constants.READ,
                      provisioning: {
                         lastIncrease: 1492346261,
@@ -152,6 +153,7 @@ describe('DynamoResourceLister', function() {
                      resourceType: 'table',
                      name: 'Tbl1',
                      tableName: 'Tbl1',
+                     tableCreationDateTime: 'Mon Apr 18 2017 16:46:37 GMT-0400 (EDT)',
                      capacityType: constants.WRITE,
                      provisioning: {
                         lastIncrease: 1492346261,
@@ -164,6 +166,7 @@ describe('DynamoResourceLister', function() {
                      resourceType: 'index',
                      name: 'Tbl1::Name',
                      tableName: 'Tbl1',
+                     tableCreationDateTime: 'Mon Apr 18 2017 16:46:37 GMT-0400 (EDT)',
                      indexName: 'Name',
                      capacityType: constants.READ,
                      provisioning: {
@@ -177,6 +180,7 @@ describe('DynamoResourceLister', function() {
                      resourceType: 'index',
                      name: 'Tbl1::Name',
                      tableName: 'Tbl1',
+                     tableCreationDateTime: 'Mon Apr 18 2017 16:46:37 GMT-0400 (EDT)',
                      indexName: 'Name',
                      capacityType: constants.WRITE,
                      provisioning: {
@@ -199,6 +203,7 @@ describe('DynamoResourceLister', function() {
             resourceType: 'table',
             name: 'Tbl1',
             tableName: 'Tbl1',
+            tableCreationDateTime: 'Mon Apr 18 2017 16:46:37 GMT-0400 (EDT)',
             capacityType: constants.READ,
             provisioning: {
                lastIncrease: 1492346261,
@@ -214,6 +219,7 @@ describe('DynamoResourceLister', function() {
             resourceType: 'table',
             name: 'Tbl1',
             tableName: 'Tbl1',
+            tableCreationDateTime: 'Mon Apr 18 2017 16:46:37 GMT-0400 (EDT)',
             capacityType: constants.WRITE,
             provisioning: {
                lastIncrease: 1492346261,
@@ -229,11 +235,12 @@ describe('DynamoResourceLister', function() {
    describe('convertIndexToResource', function() {
 
       it('converts index to resource - read', function() {
-         expect(lister.convertIndexToResource('Tbl1', mockTbl1NameIndex, constants.READ)).to.eql({
+         expect(lister.convertIndexToResource(mockTbl1, mockTbl1NameIndex, constants.READ)).to.eql({
             resourceType: 'index',
             name: 'Tbl1::Name',
             tableName: 'Tbl1',
             indexName: 'Name',
+            tableCreationDateTime: 'Mon Apr 18 2017 16:46:37 GMT-0400 (EDT)',
             capacityType: constants.READ,
             provisioning: {
                lastIncrease: 1492546261,
@@ -245,11 +252,48 @@ describe('DynamoResourceLister', function() {
       });
 
       it('converts index to resource - write', function() {
+         expect(lister.convertIndexToResource(mockTbl1, mockTbl1NameIndex, constants.WRITE)).to.eql({
+            resourceType: 'index',
+            name: 'Tbl1::Name',
+            tableName: 'Tbl1',
+            indexName: 'Name',
+            tableCreationDateTime: 'Mon Apr 18 2017 16:46:37 GMT-0400 (EDT)',
+            capacityType: constants.WRITE,
+            provisioning: {
+               lastIncrease: 1492546261,
+               lastDecrease: 1492241142,
+               numberOfDecreasesToday: 2,
+               currentCapacity: 12,
+            },
+         });
+      });
+
+      // DEPRECATED
+      it('converts index to resource using string table name - read', function() {
+         expect(lister.convertIndexToResource('Tbl1', mockTbl1NameIndex, constants.READ)).to.eql({
+            resourceType: 'index',
+            name: 'Tbl1::Name',
+            tableName: 'Tbl1',
+            indexName: 'Name',
+            tableCreationDateTime: undefined,
+            capacityType: constants.READ,
+            provisioning: {
+               lastIncrease: 1492546261,
+               lastDecrease: 1492241142,
+               numberOfDecreasesToday: 2,
+               currentCapacity: 8,
+            },
+         });
+      });
+
+      // DEPRECATED
+      it('converts index to resource using string table name - write', function() {
          expect(lister.convertIndexToResource('Tbl1', mockTbl1NameIndex, constants.WRITE)).to.eql({
             resourceType: 'index',
             name: 'Tbl1::Name',
             tableName: 'Tbl1',
             indexName: 'Name',
+            tableCreationDateTime: undefined,
             capacityType: constants.WRITE,
             provisioning: {
                lastIncrease: 1492546261,


### PR DESCRIPTION
This PR adds the `MinimumMinutesBeforeAdjustingNewTable` config option to delay the provisioner's initial adjustment to a table's provisioning. These changes fix the following error when deploying a global table using the [silvermine/cloudformation-custom-resources](https://github.com/silvermine/cloudformation-custom-resources) [DynamoDBGlobalTable resource](https://github.com/silvermine/cloudformation-custom-resources/blob/99ede86e5b98fb3548202c4d0a638b8afc3f4dda/src/DynamoDBGlobalTable.js).

> An error occurred: TestGlobalTable - Failed to create resource. One or more parameter values were invalid: Constraint not met: 'Tables are manually provisioned but write capacity units do not match.'. [Table in replica 'eu-west-1' has write capacity units: 1., Table in replica 'us-east-1' has write capacity units: 2.].